### PR TITLE
Do not validate receipts from mismatching environments

### DIFF
--- a/app/models/apple_receipt.rb
+++ b/app/models/apple_receipt.rb
@@ -9,4 +9,12 @@ class AppleReceipt
       RECEIPT_URL
     end
   end
+
+  def self.environment(params = {})
+    if endpoint_url(params) == SANDBOX_URL
+      "sandbox"
+    else
+      "production"
+    end
+  end
 end

--- a/app/models/receipt.rb
+++ b/app/models/receipt.rb
@@ -1,6 +1,11 @@
 class Receipt < ActiveRecord::Base
   belongs_to :user
 
+  enum environment: {
+    production: 0,
+    sandbox: 1,
+  }
+
   def self.for_payload(payload)
     where(payload)
   end

--- a/db/migrate/20151223134225_add_environment_to_receipt.rb
+++ b/db/migrate/20151223134225_add_environment_to_receipt.rb
@@ -1,0 +1,5 @@
+class AddEnvironmentToReceipt < ActiveRecord::Migration
+  def change
+    add_column :receipts, :environment, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151215202900) do
+ActiveRecord::Schema.define(version: 20151223134225) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,11 +33,12 @@ ActiveRecord::Schema.define(version: 20151215202900) do
   add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
 
   create_table "receipts", force: :cascade do |t|
-    t.integer  "user_id",                 null: false
-    t.string   "token",      default: "", null: false
-    t.string   "data",       default: "", null: false
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
+    t.integer  "user_id",                  null: false
+    t.string   "token",       default: "", null: false
+    t.string   "data",        default: "", null: false
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+    t.integer  "environment", default: 0,  null: false
   end
 
   add_index "receipts", ["user_id"], name: "index_receipts_on_user_id", using: :btree

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,7 +1,8 @@
 FactoryGirl.define do
   factory :receipt do
-    user
+    environment "production"
     token "some-token"
+    user
   end
 
   factory :user do

--- a/spec/models/apple_receipt_spec.rb
+++ b/spec/models/apple_receipt_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+
+describe AppleReceipt do
+  describe ".endpoint_url" do
+    context "given sandbox parameters" do
+      it "returns the sandbox url" do
+        result = AppleReceipt.endpoint_url(sandbox: "1")
+
+        expect(result).to eq AppleReceipt::SANDBOX_URL
+      end
+    end
+
+    context "given non-sandbox parameters" do
+      it "returns the production url" do
+        result = AppleReceipt.endpoint_url({})
+
+        expect(result).to eq AppleReceipt::RECEIPT_URL
+      end
+    end
+  end
+
+  describe ".environment" do
+    context "given sandbox parameters" do
+      it "returns sandbox" do
+        result = AppleReceipt.environment(sandbox: "1")
+
+        expect(result).to eq "sandbox"
+      end
+    end
+
+    context "given non-sandbox parameters" do
+      it "returns production" do
+        result = AppleReceipt.environment({})
+
+        expect(result).to eq "production"
+      end
+    end
+  end
+end

--- a/spec/models/receipt_validator_spec.rb
+++ b/spec/models/receipt_validator_spec.rb
@@ -65,7 +65,11 @@ describe ReceiptValidator do
       context "when the token matches" do
         it "is a success" do
           user = stubbed_user
-          receipt = double("Receipt", token: "abc123")
+          receipt = double(
+            "Receipt",
+            token: "abc123",
+            environment: "production",
+          )
           payload = {
             data: "data",
             token: "abc123",
@@ -83,7 +87,11 @@ describe ReceiptValidator do
       context "when the token does not match" do
         it "is a bad request" do
           user = stubbed_user
-          receipt = double("Receipt", token: "abc123")
+          receipt = double(
+            "Receipt",
+            token: "abc123",
+            environment: "production",
+          )
           payload = {
             data: "data",
             token: "321cba",

--- a/spec/requests/api/v1/verification_spec.rb
+++ b/spec/requests/api/v1/verification_spec.rb
@@ -123,6 +123,23 @@ describe "Verification of the Apple receipt" do
     end
   end
 
+  context "given an already validated sandbox receipt" do
+    it "is a bad request when it is validated against production" do
+      receipt = create(:receipt, environment: "sandbox")
+      user = receipt.user
+      payload = {
+        receipt: {
+          data: receipt.data,
+          token: receipt.token,
+        },
+      }
+
+      auth_post api_v1_verifications_path, payload, user.token
+
+      expect(response).to be_bad_request
+    end
+  end
+
   it "respects sandbox" do
     with_fake_apple_receipt(url: "https://sandbox.example.com") do
       user = create(:user)


### PR DESCRIPTION
A receipt belongs to a certain environment, with that knowledge - a user
cannot validate a receipt that is a "Sandbox" receipt in "Production".

Changes:
- Add `Receipt#environment` enum that default to "production".

https://trello.com/c/pvfDpzBc
