### PR TITLE
Persist Apple validation results

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -1,8 +1,8 @@
 # https://github.com/ddollar/forego
 ASSET_HOST=localhost:3000
 APPLICATION_HOST=localhost:3000
-APPLE_RECEIPT_ENDPOINT=https://example.com/
-APPLE_SANDBOX_ENDPOINT=https://sandbox.example.com/
+APPLE_RECEIPT_ENDPOINT=https://buy.itunes.apple.com/verifyReceipt
+APPLE_SANDBOX_ENDPOINT=https://sandbox.itunes.apple.com/verifyReceipt
 RACK_ENV=development
 SECRET_KEY_BASE=development_secret
 EXECJS_RUNTIME=Node

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,6 +1,7 @@
 module Api
   module V1
     class BaseController < ApplicationController
+      protect_from_forgery with: :null_session
       before_filter :authenticate
 
       private

--- a/app/controllers/api/v1/verifications_controller.rb
+++ b/app/controllers/api/v1/verifications_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class VerificationsController < BaseController
       def create
-        render nothing: true, status: validation.http_status
+        render json: validation, status: validation.http_status
       end
 
       private
@@ -15,12 +15,16 @@ module Api
         ReceiptValidator.new(
           payload: receipt_params,
           user: current_user,
-          sandbox: params[:sandbox] || 0,
+          sandbox: sandbox,
         )
       end
 
+      def sandbox
+        params[:sandbox] || "0"
+      end
+
       def receipt_params
-        params.require(:receipt).permit(:data, :token)
+        params.require(:receipt).permit!
       end
     end
   end

--- a/app/models/receipt.rb
+++ b/app/models/receipt.rb
@@ -1,4 +1,13 @@
 class Receipt < ActiveRecord::Base
+  APPLE_METADATA_KEY_WHITELIST = %w(
+    application_version
+    bundle_id
+    download_id
+    original_purchase_date_ms
+    receipt_creation_date_ms
+    request_date_ms
+  ).freeze
+
   belongs_to :user
 
   enum environment: {
@@ -6,7 +15,13 @@ class Receipt < ActiveRecord::Base
     sandbox: 1,
   }
 
-  def self.for_payload(payload)
-    where(payload)
+  def self.create_from_apple_payload(payload)
+    new_payload = {
+      data: payload["data"],
+      token: payload["token"],
+      metadata: payload["receipt"].slice(*APPLE_METADATA_KEY_WHITELIST),
+    }
+
+    create(new_payload)
   end
 end

--- a/db/migrate/20151223150829_add_metadata_to_receipt.rb
+++ b/db/migrate/20151223150829_add_metadata_to_receipt.rb
@@ -1,0 +1,5 @@
+class AddMetadataToReceipt < ActiveRecord::Migration
+  def change
+    add_column :receipts, :metadata, :jsonb, default: "{}", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151223145759) do
+ActiveRecord::Schema.define(version: 20151223150829) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 20151223145759) do
     t.datetime "created_at",               null: false
     t.datetime "updated_at",               null: false
     t.integer  "environment", default: 0,  null: false
+    t.jsonb    "metadata",    default: {}, null: false
   end
 
   add_index "receipts", ["user_id"], name: "index_receipts_on_user_id", using: :btree

--- a/spec/models/receipt_spec.rb
+++ b/spec/models/receipt_spec.rb
@@ -3,12 +3,18 @@ require "rails_helper"
 describe Receipt do
   it { is_expected.to belong_to(:user) }
 
-  describe ".for_payload" do
-    it "returns the receipts matching the given payload" do
-      receipt = create(:receipt, token: "abc")
-      _another_receipt = create(:receipt, token: "123")
+  describe ".create_from_apple_payload" do
+    it "massages the payload from Apple" do
+      user = create(:user)
+      payload = JSON.
+        parse(fixture_for("receipt-response.json")).
+        merge("data" => "data", "token" => "token")
 
-      expect(Receipt.for_payload(token: "abc")).to eq [receipt]
+      receipt = user.receipts.create_from_apple_payload(payload)
+
+      expected_payload = payload["receipt"].
+        slice(*Receipt::APPLE_METADATA_KEY_WHITELIST)
+      expect(receipt.metadata).to eq expected_payload
     end
   end
 end

--- a/spec/models/response_spec.rb
+++ b/spec/models/response_spec.rb
@@ -1,15 +1,18 @@
-require "spec_helper"
-require "app/models/response"
+require "rails_helper"
 
 describe Response do
   describe ".for" do
     context "given a status of 0" do
       it "returns a SuccessfulRequest" do
-        json = { "status" => 0 }
+        apple_receipt = JSON.parse(fixture_for("receipt-response.json"))
+        json = apple_receipt.merge("status" => 0)
+        expected_json = apple_receipt["receipt"].
+          slice(*Receipt::APPLE_METADATA_KEY_WHITELIST)
 
         result = Response.for(json)
 
         expect(result).to be_a Response::SuccessfulRequest
+        expect(result.as_json).to eq(expected_json)
       end
     end
 
@@ -20,6 +23,7 @@ describe Response do
         result = Response.for(json)
 
         expect(result).to be_a Response::UnauthenticatedError
+        expect(result.as_json).to eq({})
       end
     end
 
@@ -30,6 +34,7 @@ describe Response do
         result = Response.for(json)
 
         expect(result).to be_a Response::BadRequestError
+        expect(result.as_json).to eq({})
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 $: << File.expand_path("../..", __FILE__)
 
+ENV["APPLE_SANDBOX_ENDPOINT"] = "https://sandbox.example.com"
+
 if ENV.fetch("COVERAGE", false)
   require "simplecov"
   SimpleCov.start "rails"

--- a/spec/support/fixture_helpers.rb
+++ b/spec/support/fixture_helpers.rb
@@ -1,0 +1,9 @@
+module FixtureHelpers
+  def fixture_for(name)
+    File.read("spec/support/fixtures/#{name}")
+  end
+end
+
+RSpec.configure do |config|
+  config.include FixtureHelpers
+end

--- a/spec/support/fixtures/receipt-response.json
+++ b/spec/support/fixtures/receipt-response.json
@@ -1,0 +1,24 @@
+{
+   "environment" : "Production",
+   "status" : 0,
+   "receipt" : {
+      "original_purchase_date_pst" : "2014-01-01 01:01:01 Europe/Stockholm",
+      "receipt_creation_date_ms" : "1000000000001",
+      "adam_id" : 100000001,
+      "receipt_creation_date_pst" : "2014-01-01 01:01:01 Europe/Stockholm",
+      "request_date_pst" : "2014-01-01 01:01:01 Europe/Stockholm",
+      "original_application_version" : "1.0.0",
+      "request_date_ms" : "1450881962563",
+      "original_purchase_date" : "2014-01-01 01:01:01 Europe/Stockholm",
+      "bundle_id" : "com.thoughtbot.keelhaul",
+      "receipt_type" : "Production",
+      "in_app" : [],
+      "download_id" : 10000000000001,
+      "application_version" : "1.0.0",
+      "version_external_identifier" : 100000001,
+      "app_item_id" : 100000001,
+      "receipt_creation_date" : "2014-01-01 01:01:01 Etc/Gmt",
+      "request_date" : "2014-01-01 01:01:01 Etc/Gmt",
+      "original_purchase_date_ms" : "1000000000001"
+   }
+}

--- a/spec/support/mock_apple_receipt.rb
+++ b/spec/support/mock_apple_receipt.rb
@@ -3,11 +3,18 @@ module MockAppleReceipt
     default_options = {
       status: 0,
       url: AppleReceipt.endpoint_url,
+      file: "spec/support/fixtures/receipt-response.json",
     }
     options = default_options.merge(options)
+    body = JSON.parse(File.read(options[:file]))
 
-    request_stub = stub_request(:post, options[:url]).
-      to_return(body: { status: options[:status] }.to_json, status: 200)
+    request_stub = stub_request(
+      :post,
+      options[:url],
+    ).to_return(
+      body: body.merge(status: options[:status]).to_json,
+      status: 200,
+    )
 
     yield
 


### PR DESCRIPTION
Persist data returned from Apple's validation endpoint in order to not
have to make subsequent requests for already validated receipts.
- Remove unused `Receipt.for_payload`
- Extract `sandbox` and make it a string
- Introduce `Response::*#on_success` for handling actions on successful
  requests

Update request format for requests to Apple's validation endpoint to be
in line with the Apple docs.

Use `null_session` forgery protection for API

Previously, API requests would be denied since they did not contain a
valid CSRF token. By using the `null_session` forgery protection
strategy for API endpoints, requests are no longer denied. Instead the
Rails session features are disabled. This is fine since the API doesn't
use session cookies.

Fill in Apple endpoints in the sample .env file

The endpoints are listed in the Apple docs and are very helpful when
developing the app locally.
