### PR TITLE
Rename receipt token to device hash

### DIFF
--- a/app/dashboards/receipt_dashboard.rb
+++ b/app/dashboards/receipt_dashboard.rb
@@ -10,7 +10,7 @@ class ReceiptDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     user: Field::BelongsTo,
     id: Field::Number,
-    token: Field::String,
+    device_hash: Field::String,
     data: Field::String,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
@@ -26,7 +26,7 @@ class ReceiptDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = [
     :user,
     :id,
-    :token,
+    :device_hash,
     :data,
   ]
 
@@ -35,7 +35,7 @@ class ReceiptDashboard < Administrate::BaseDashboard
   SHOW_PAGE_ATTRIBUTES = [
     :user,
     :id,
-    :token,
+    :device_hash,
     :data,
     :created_at,
     :updated_at,
@@ -48,7 +48,7 @@ class ReceiptDashboard < Administrate::BaseDashboard
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = [
     :user,
-    :token,
+    :device_hash,
     :data,
     :environment,
     :metadata,

--- a/app/models/receipt.rb
+++ b/app/models/receipt.rb
@@ -20,7 +20,7 @@ class Receipt < ActiveRecord::Base
   def self.create_from_apple_payload(payload)
     new_payload = {
       data: payload["data"],
-      token: payload["token"],
+      device_hash: payload["device_hash"],
       environment: environment_from_payload(payload),
       metadata: payload["receipt"].slice(*APPLE_METADATA_KEY_WHITELIST),
     }

--- a/app/models/receipt_validator.rb
+++ b/app/models/receipt_validator.rb
@@ -14,7 +14,7 @@ class ReceiptValidator
       validation.on_success { create_receipt(response.body) }
     elsif mismatching_environment?
       Response::BadRequestError.new
-    elsif token_matches?
+    elsif device_hash_matches?
       Response::SuccessfulRequest.new(matching_receipt.metadata)
     else
       Response::UnauthenticatedError.new
@@ -51,8 +51,8 @@ class ReceiptValidator
     matching_receipt.environment != current_environment
   end
 
-  def token_matches?
-    matching_receipt.token == payload[:token]
+  def device_hash_matches?
+    matching_receipt.device_hash == payload[:device_hash]
   end
 
   def matching_receipt
@@ -61,7 +61,7 @@ class ReceiptValidator
 
   def create_receipt(json)
     user.receipts.create_from_apple_payload(
-      json.merge("data" => payload[:data], "token" => payload[:token]),
+      json.merge("data" => payload[:data], "device_hash" => payload[:device_hash]),
     )
   end
 

--- a/db/migrate/20160310151326_rename_token_column.rb
+++ b/db/migrate/20160310151326_rename_token_column.rb
@@ -1,0 +1,5 @@
+class RenameTokenColumn < ActiveRecord::Migration
+  def change
+    rename_column :receipts, :token, :device_hash
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160306143558) do
+ActiveRecord::Schema.define(version: 20160310151326) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,7 +34,7 @@ ActiveRecord::Schema.define(version: 20160306143558) do
 
   create_table "receipts", force: :cascade do |t|
     t.integer  "user_id",                  null: false
-    t.string   "token",       default: "", null: false
+    t.string   "device_hash", default: "", null: false
     t.string   "data",        default: "", null: false
     t.datetime "created_at",               null: false
     t.datetime "updated_at",               null: false

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :receipt do
     environment "production"
-    token "some-token"
+    device_hash "some-hash"
     user
   end
 

--- a/spec/models/receipt_spec.rb
+++ b/spec/models/receipt_spec.rb
@@ -8,7 +8,7 @@ describe Receipt do
       user = create(:user)
       payload = JSON.
         parse(fixture_for("receipt-response.json")).
-        merge("data" => "data", "token" => "token")
+        merge("data" => "data", "device_hash" => "device_hash")
 
       receipt = user.receipts.create_from_apple_payload(payload)
 

--- a/spec/models/receipt_validator_spec.rb
+++ b/spec/models/receipt_validator_spec.rb
@@ -21,7 +21,7 @@ describe ReceiptValidator do
             user = stubbed_user
             payload = {
               data: "data",
-              token: "token",
+              device_hash: "device_hash",
             }
             validator = ReceiptValidator.new(payload: payload, user: user)
 
@@ -62,18 +62,18 @@ describe ReceiptValidator do
     end
 
     context "when the receipt has been validated before" do
-      context "when the token matches" do
+      context "when the device hash matches" do
         it "is a success" do
           user = stubbed_user
           receipt = double(
             "Receipt",
-            token: "abc123",
+            device_hash: "abc123",
             environment: "production",
             metadata: {},
           )
           payload = {
             data: "data",
-            token: "abc123",
+            device_hash: "abc123",
           }
           allow(user.receipts).to receive(:find_by).and_return(receipt)
           validator = ReceiptValidator.new(payload: payload, user: user)
@@ -85,17 +85,17 @@ describe ReceiptValidator do
         end
       end
 
-      context "when the token does not match" do
+      context "when the device hash does not match" do
         it "is an unauthenticated request" do
           user = stubbed_user
           receipt = double(
             "Receipt",
-            token: "abc123",
+            device_hash: "abc123",
             environment: "production",
           )
           payload = {
             data: "data",
-            token: "321cba",
+            device_hash: "321cba",
           }
           allow(user.receipts).to receive(:find_by).and_return(receipt)
           validator = ReceiptValidator.new(payload: payload, user: user)

--- a/spec/requests/api/v1/verification_spec.rb
+++ b/spec/requests/api/v1/verification_spec.rb
@@ -15,7 +15,7 @@ describe "Verification of the Apple receipt" do
           {
             receipt: {
               data: "ABC",
-              token: "unknown-token",
+              device_hash: "unknown-hash",
             },
           },
           user.token,
@@ -38,7 +38,7 @@ describe "Verification of the Apple receipt" do
           {
             receipt: {
               data: "ABC",
-              token: "unknown-token",
+              device_hash: "unknown-hash",
             },
           },
           user.token,
@@ -52,7 +52,7 @@ describe "Verification of the Apple receipt" do
         {
           receipt: {
             data: "ABC",
-            token: "unknown-token",
+            device_hash: "unknown-hash",
           },
         },
         user.token,
@@ -68,13 +68,13 @@ describe "Verification of the Apple receipt" do
       receipt = create(
         :receipt,
         user: user,
-        token: "known-token",
+        device_hash: "known-hash",
         data: "ABC",
       )
       payload = {
         receipt: {
           data: receipt.data,
-          token: receipt.token,
+          device_hash: receipt.device_hash,
         },
       }
 
@@ -86,13 +86,13 @@ describe "Verification of the Apple receipt" do
 
   context "valid receipt, known API key, known token for a different receipt" do
     it "is a failure" do
-      receipt = create(:receipt, token: "receipt A")
-      other_receipt = create(:receipt, token: "receipt B")
+      receipt = create(:receipt, device_hash: "receipt A")
+      other_receipt = create(:receipt, device_hash: "receipt B")
       user = receipt.user
       payload = {
         receipt: {
           data: receipt.data,
-          token: other_receipt.token,
+          device_hash: other_receipt.device_hash,
         },
       }
 
@@ -138,7 +138,7 @@ describe "Verification of the Apple receipt" do
       payload = {
         receipt: {
           data: receipt.data,
-          token: receipt.token,
+          device_hash: receipt.device_hash,
         },
       }
 
@@ -157,7 +157,7 @@ describe "Verification of the Apple receipt" do
         {
           receipt: {
             data: "ABC",
-            token: "unknown-token",
+            device_hash: "unknown-hash",
           },
         },
         user.token,


### PR DESCRIPTION
Avoid confusion with user tokens
